### PR TITLE
Use URI class, not URL

### DIFF
--- a/app/src/main/java/com/orgzly/android/ui/share/ShareActivity.java
+++ b/app/src/main/java/com/orgzly/android/ui/share/ShareActivity.java
@@ -40,8 +40,8 @@ import com.orgzly.android.util.MiscUtils;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
 
 import javax.inject.Inject;
 
@@ -153,9 +153,9 @@ public class ShareActivity extends CommonActivity
                 // if it's a url with title, let's turn it into org url
                 if (data.content != null && data.title != null) {
                     try {
-                        new URL(data.content);
+                        new URI(data.content);
                         data.content = "[[" + data.content + "][" + data.title + "]]";
-                    } catch (MalformedURLException ignored) {}
+                    } catch (URISyntaxException ignored) {}
                 }
 
                 // TODO: Was used for direct share shortcuts to pass the book name. Used someplace else?


### PR DESCRIPTION
After discussion with @lingnand:

>>> Good idea to use proper class to parse. Can we use java.net.URI instead? A lot of org links are not web URL but URI e.g. file:a/b/c

>> Sure. I was thinking that one may not want to handle all types of URIs like this. But if you can imagine a use case, then let's do it.

> I use an Email app that generate links to emails, which fall into this category (basically, Android app links are this format)